### PR TITLE
Long tweet logic

### DIFF
--- a/lib/gnip_api.rb
+++ b/lib/gnip_api.rb
@@ -58,9 +58,10 @@ module GnipApi
       @configuration.adapter_class ? true : false
     end
 
-    def deprecation_warning old_method, new_method, reason = nil
-      message = "[DEPRECATION] `#{old_method}` will be removed in the future, use `#{new_method}` instead."
-      message += " Reason: #{reason}" if reason
+    def deprecation_warning old_method, new_method, file_caller, reason = nil
+      message = "[DEPRECATION] `#{old_method}` will be removed in the future, use `#{new_method}` instead. "
+      message += "Reason: #{reason}. " if reason
+      message += "Called from: #{file_caller}"
       warn(message)
     end
   end

--- a/lib/gnip_api.rb
+++ b/lib/gnip_api.rb
@@ -57,5 +57,11 @@ module GnipApi
     def adapter_class?
       @configuration.adapter_class ? true : false
     end
+
+    def deprecation_warning old_method, new_method, reason = nil
+      message = "[DEPRECATION] `#{old_method}` will be removed in the future, use `#{new_method}` instead."
+      message += " Reason: #{reason}" if reason
+      warn(message)
+    end
   end
 end

--- a/lib/gnip_api/gnip/activity.rb
+++ b/lib/gnip_api/gnip/activity.rb
@@ -83,7 +83,7 @@ module Gnip
     end
 
     def hidden_data?
-      GnipApi.deprecation_warning __method__, :long_object?
+      GnipApi.deprecation_warning __method__, :long_object?, Kernel.caller.first
       !@display_text_range.nil? && !@long_object.nil?
     end
   end

--- a/lib/gnip_api/gnip/activity.rb
+++ b/lib/gnip_api/gnip/activity.rb
@@ -83,6 +83,7 @@ module Gnip
     end
 
     def hidden_data?
+      GnipApi.deprecation_warning __method__, :long_object?
       !@display_text_range.nil? && !@long_object.nil?
     end
   end

--- a/lib/gnip_api/gnip/activity.rb
+++ b/lib/gnip_api/gnip/activity.rb
@@ -73,6 +73,15 @@ module Gnip
       verb == 'share'
     end
 
+    def long_object?
+      !@long_object.nil?
+    end
+
+    def normalized_body
+      return @body unless long_object?
+      return @long_object['body']
+    end
+
     def hidden_data?
       !@display_text_range.nil? && !@long_object.nil?
     end

--- a/spec/gnip_api/gnip/activity_spec.rb
+++ b/spec/gnip_api/gnip/activity_spec.rb
@@ -5,9 +5,13 @@ describe Gnip::Message do
     let(:long_tweet){ JSON.parse(File.read(fixture_path.join('activities', 'real_activity_long_object.json'))) }
     let(:parsed_tweet){ Gnip::Activity.new(long_tweet) }
     it('parses without problem'){ expect(Proc.new{Gnip::Activity.new(long_tweet)}).not_to raise_error }
-    it('has hidden data'){ expect(parsed_tweet.hidden_data?).to eq(true) }
+    it('is long tweet'){ expect(parsed_tweet.long_object?).to eq(true) }
     it('has display_text_range data'){ expect(parsed_tweet.display_text_range).not_to eq(nil) }
     it('has long_object data'){ expect(parsed_tweet.long_object).not_to eq(nil) }
+
+    context '#normalized_body' do
+      it('returns long object body'){ expect(parsed_tweet.normalized_body).to eq(long_tweet['long_object']['body']) }
+    end
   end
 
   context 'twitter' do


### PR DESCRIPTION
Addresses the issue #3 by replacing the method with a #long_object? method that detects that piece of data. The previous method also tried to get a body range property from the activity that wasn't always present, marking as non-long-tweets activities with the 'long_object' data.

Minor improvements around as well:
- General deprecation warning method.
- #normalized_body method that always outputs the largest body present.